### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,5 @@
 [![Build Status](https://travis-ci.org/cvut/sirius.svg?branch=master)](https://travis-ci.org/cvut/sirius)
 [![Code Climate](https://img.shields.io/codeclimate/github/cvut/sirius.svg)](https://codeclimate.com/github/cvut/sirius)
 [![Code Coverage](https://img.shields.io/codeclimate/coverage/github/cvut/sirius.svg)](https://codeclimate.com/github/cvut/sirius)
+[![Inline docs](http://inch-pages.github.io/github/cvut/sirius.svg)](http://inch-pages.github.io/github/cvut/sirius)
 [![Dependency Status](https://www.versioneye.com/user/projects/535a56bafe0d07a3cb0000a6/badge.svg)](https://www.versioneye.com/user/projects/535a56bafe0d07a3cb0000a6)


### PR DESCRIPTION
I just added the badge @flexik requested to your README: ![Inline docs](http://inch-pages.github.io/github/cvut/sirius.png)

Your status page for this project is http://inch-pages.github.io/github/cvut/sirius

Thanks for giving this a shot!
