### PR TITLE
Switch to Ruby v2.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.1.2
+  - 2.1.3
 addons:
-  postgresql: "9.3"
+  postgresql: '9.3'
   code_climate:
     repo_token: a813ce884be14a158262d4e05906c0b6f4e7f4533c41cdf88bda7da84d88297f
 cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.1.2'
+ruby '2.1.3'
 
 gem 'rake'
 


### PR DESCRIPTION
2.1.3 has [some nice tweaks](https://bugs.ruby-lang.org/issues/9607) for the new GC which dramatically drop memory consumption, so I would like to push this into the production ASAP, especially before adding additional background runner.
