### PR TITLE
Optimize frequently used event queries

### DIFF
--- a/app/interactors/api/represent_events_json.rb
+++ b/app/interactors/api/represent_events_json.rb
@@ -16,7 +16,8 @@ module Interactors
         @events = paginated.dataset
 
         @compounds = CompoundEvents.perform(events: @events, params: params).compounds
-        @representer = EventsRepresenter.for_collection.prepare(convert_events(@events, student_output_permitted))
+        converted_events = convert_events(@events.eager(:parallel).all, student_output_permitted)
+        @representer = EventsRepresenter.for_collection.prepare(converted_events)
       end
 
       def to_hash(options = {})

--- a/app/interactors/format_events_ical.rb
+++ b/app/interactors/format_events_ical.rb
@@ -21,7 +21,7 @@ class FormatEventsIcal
   # Adds events to an ICalendar and convert it to a text representation.
   # @return [String] ICalendar as a string.
   def perform(events: [])
-    @events = Array(events)
+    @events = events.eager(:parallel, :course, :room).all
 
     @events.each do |e|
       @calendar.add_event IcalEvent(e).to_ical

--- a/spec/interactors/format_events_ical_spec.rb
+++ b/spec/interactors/format_events_ical_spec.rb
@@ -6,7 +6,8 @@ describe FormatEventsIcal do
   include IcalendarHelper
 
   let(:event) { Fabricate.build(:event, id: 42, starts_at: '2014-04-05 14:30', ends_at: '2014-04-05 16:00', course_id: 'MI-RUB', event_type: 'tutorial') }
-  let(:interactor) { described_class.perform(events: event) }
+  let(:event_dataset) { double(:dataset, all: [event]).as_null_object }
+  let(:interactor) { described_class.perform(events: event_dataset) }
   let(:result) { interactor.ical }
   let(:calendar) { parse_icalendar(result).first } # Parser returns array of calendars
   let(:tzid) { 'Europe/Prague' }


### PR DESCRIPTION
I've added some eager loading to prevent N+1 queries on most common event requests.