### PR TITLE
Add resource that provides semester-related information about the given day

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'rufus-scheduler', '~> 3.1.0', require: false
 
 ## Helper stuff
 gem 'activesupport'
-gem 'corefines', '~> 1.8'
+gem 'corefines', '~> 1.9'
 gem 'role_playing', github: 'jnv/role_playing'
 gem 'logging'
 gem 'oauth2', github: 'cvut/oauth2', ref: '13753d6'

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :test do
   gem 'committee'
   gem 'rspec', '~> 3.3'
   gem 'rspec-collection_matchers'
+  gem 'rspec-http', '~> 0.11'
   gem 'rspec-parameterized', github: 'jnv/rspec-parameterized', branch: 'badbf07'
   gem 'rack-test'
   gem 'bogus'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
     concord (0.1.5)
       adamantium (~> 0.2.0)
       equalizer (~> 0.0.9)
-    corefines (1.8.0)
+    corefines (1.9.0)
     coveralls (0.8.2)
       json (~> 1.8)
       rest-client (>= 1.6.8, < 2)
@@ -347,7 +347,7 @@ DEPENDENCIES
   chewy!
   codeclimate-test-reporter
   committee
-  corefines (~> 1.8)
+  corefines (~> 1.9)
   coveralls
   database_cleaner
   dotenv

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,9 @@ GEM
     rspec-expectations (3.3.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
+    rspec-http (0.11.0)
+      rack (~> 1.0)
+      rspec (~> 3.0)
     rspec-mocks (3.3.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
@@ -382,6 +385,7 @@ DEPENDENCIES
   role_playing!
   rspec (~> 3.3)
   rspec-collection_matchers
+  rspec-http (~> 0.11)
   rspec-parameterized!
   rufus-scheduler (~> 3.1.0)
   sentry-raven

--- a/app/api/base.rb
+++ b/app/api/base.rb
@@ -4,6 +4,7 @@ require 'json'
 require 'errors_helper'
 require 'sirius_api'
 require 'api/events_endpoints'
+require 'api/faculties_endpoints'
 require 'api/schedule_exceptions_endpoints'
 require 'api/search_endpoints'
 require 'api/semesters_endpoints'
@@ -40,6 +41,7 @@ module API
 
     # Mount your api classes here
     mount API::EventsEndpoints
+    mount API::FacultiesEndpoints
     mount API::ScheduleExceptionsEndpoints
     mount API::SearchEndpoints
     mount API::SemestersEndpoints

--- a/app/api/faculties_endpoints.rb
+++ b/app/api/faculties_endpoints.rb
@@ -1,0 +1,87 @@
+require 'api_helper'
+require 'corefines'
+require 'date_refinements'
+require 'representers/semester_days_representer'
+require 'representers/semester_weeks_representer'
+require 'sirius_api/semester_schedule'
+
+module API
+  class FacultiesEndpoints < Grape::API
+    using Corefines::Object[:then, :else]
+    using ::DateRefinements
+
+    helpers ApiHelper
+
+    helpers do
+      def get_day(date)
+        SiriusApi::SemesterSchedule.resolve_day(date, params[:faculty_id])
+          .then { |it| SemesterDaysRepresenter.new(it) }
+          .else { not_found! }
+      end
+
+      def get_week(date)
+        SiriusApi::SemesterSchedule.resolve_week(date, params[:faculty_id])
+          .then { |it| SemesterWeeksRepresenter.new(it) }
+          .else { not_found! }
+      end
+
+      def check_faculty!(faculty_id)
+        DB.select(true)
+          .where(FacultySemester.where(faculty: faculty_id).exists)
+          .single_value
+          .else { error!({message: "Faculty with code #{faculty_id} not found"}, 404) }
+      end
+    end
+
+    resource :faculties do
+
+      params { requires :faculty_id, type: Integer, desc: 'Faculty code (5 digits)' }
+      route_param :faculty_id do
+
+        resource :schedule do
+
+          resource :days do
+            params { use :date_range }
+
+            get do
+              check_faculty! params[:faculty_id]
+              SemesterDaysRepresenter.for_collection.new(
+                SiriusApi::SemesterSchedule.resolve_days(params[:from], params[:to], params[:faculty_id]))
+            end
+
+            resource :current do
+              get { get_day Date.today }
+            end
+
+            params { requires :date, type: Date, desc: 'Date to resolve' }
+            route_param :date do
+              get { get_day params[:date] }
+            end
+          end
+
+          resource :weeks do
+            params { use :date_range }
+
+            get do
+              check_faculty! params[:faculty_id]
+              SemesterWeeksRepresenter.for_collection.new(
+                SiriusApi::SemesterSchedule.resolve_weeks(params[:from], params[:to], params[:faculty_id]))
+            end
+
+            resource :current do
+              get { get_week Date.today.start_of_week }
+            end
+
+            params do
+              requires :year_cweek, type: String, year_cweek: true,
+                desc: 'ISO 8601 week-based year and week number'
+            end
+            route_param :year_cweek do
+              get { get_week Date.strptime(params[:year_cweek], '%G-%V') }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/api_helper.rb
+++ b/app/helpers/api_helper.rb
@@ -18,6 +18,11 @@ module ApiHelper
     optional :offset, type: Integer, min: 0, default: DEFAULT_OFFSET
   end
 
+  params :date_range do
+    optional :from, type: Date, default: Date.today
+    optional :to, type: Date, default: Date.today + 7
+  end
+
   params :username do
     requires :username, type: String, regexp: /\A[a-z0-9]+\z/i, desc: "person's username"
   end
@@ -60,5 +65,9 @@ module ApiHelper
       .for_collection
       .new(paginated.dataset.all)
       .to_hash('meta' => paginated.meta)
+  end
+
+  def not_found!
+    error!({message: 'Resource not found'}, 404)
   end
 end

--- a/app/models/faculty_semester.rb
+++ b/app/models/faculty_semester.rb
@@ -13,6 +13,11 @@ class FacultySemester < Sequel::Model
     end
   end
 
+  def self.find_by_date(date, faculty_id)
+    where(':date >= starts_at AND :date <= ends_at AND faculty = :faculty',
+          date: date, faculty: faculty_id).first
+  end
+
   def first_week_parity
     Parity.from_numeric(super)
   end

--- a/app/models/faculty_semester.rb
+++ b/app/models/faculty_semester.rb
@@ -15,7 +15,10 @@ class FacultySemester < Sequel::Model
 
   def self.find_by_date(date, faculty_id)
     where(':date >= starts_at AND :date <= ends_at AND faculty = :faculty',
-          date: date, faculty: faculty_id).first
+          date: date, faculty: faculty_id)
+      .eager(:semester_periods)
+      .limit(1)
+      .all.first  # eager loading doesn't work with Dataset.first
   end
 
   def first_week_parity

--- a/app/models/semester_period.rb
+++ b/app/models/semester_period.rb
@@ -1,8 +1,10 @@
 require 'sirius/enums/semester_period_type'
 require 'parity'
 require 'day'
+require 'date_refinements'
 
 class SemesterPeriod < Sequel::Model
+  using ::DateRefinements
 
   many_to_one :faculty_semester
 
@@ -54,6 +56,36 @@ class SemesterPeriod < Sequel::Model
 
   def regular?
     !irregular
+  end
+
+  # @return [Boolean] whether the given date is inside this period.
+  def include?(date)
+    date >= starts_at && date <= ends_at
+  end
+
+  ##
+  # Resolves a teaching week parity for the given date within this semester
+  # period. If this period is not a teaching period, the method returns `nil`.
+  #
+  # The calculation is based on difference between the period's start date and
+  # and the given date, shifted by the period's `first_week_parity`.
+  #
+  # @param date [Date]
+  # @return [Symbol, nil] `:even`, `:odd`, or `nil`
+  # @raise [ArgumentError] if the date's week is not within this period.
+  #
+  def week_parity(date)
+    return if type != :teaching
+
+    if date < starts_at.start_of_week || date > ends_at.end_of_week then
+      fail ArgumentError, "The date's week is not within this period"
+    end
+
+    weeks_since_start = ((date.start_of_week - starts_at.start_of_week) / 7).abs.floor
+    first_parity = first_week_parity == :even ? 0 : 1
+    parity = (weeks_since_start + first_parity) % 2
+
+    parity == 0 ? :even : :odd
   end
 
   alias_method :irregular?, :irregular

--- a/app/models/semester_period.rb
+++ b/app/models/semester_period.rb
@@ -14,6 +14,10 @@ class SemesterPeriod < Sequel::Model
     super Sirius::SemesterPeriodType.to_numeric(new_type)
   end
 
+  def teaching?
+    type == :teaching
+  end
+
   def first_week_parity
     Parity.from_numeric(super) if super
   end
@@ -48,4 +52,9 @@ class SemesterPeriod < Sequel::Model
     end
   end
 
+  def regular?
+    !irregular
+  end
+
+  alias_method :irregular?, :irregular
 end

--- a/app/representers/semester_days_representer.rb
+++ b/app/representers/semester_days_representer.rb
@@ -1,0 +1,20 @@
+require 'roar/decorator'
+require 'roar/json/json_api'
+
+class SemesterDaysRepresenter < Roar::Decorator
+  include Roar::JSON::JSONAPI
+
+  type :semester_days
+
+  property :date
+  property :cwday
+  property :period_type, getter: ->(*) { period.type }
+  property :irregular
+  property :teaching_week, render_nil: true
+  property :week_parity, render_nil: true
+
+  links do
+    property :semester, getter: ->(*) { "#{semester.faculty}-#{semester.code}" }
+    property :period, getter: ->(*) { period.id }
+  end
+end

--- a/app/representers/semester_weeks_representer.rb
+++ b/app/representers/semester_weeks_representer.rb
@@ -1,0 +1,20 @@
+require 'roar/decorator'
+require 'roar/json/json_api'
+
+class SemesterWeeksRepresenter < Roar::Decorator
+  include Roar::JSON::JSONAPI
+
+  type :semester_weeks
+
+  property :start_date, as: :starts_at
+  property :end_date, as: :ends_at
+  property :cweek
+  property :period_types
+  property :teaching_week, render_nil: true
+  property :week_parity, render_nil: true
+
+  links do
+    property :semester, getter: ->(*) { "#{semester.faculty}-#{semester.code}" }
+    collection :periods, getter: ->(*) { periods.map(&:id) }
+  end
+end

--- a/docs/Sirius.raml
+++ b/docs/Sirius.raml
@@ -43,13 +43,6 @@ traits:
         to:
           description: Return events up to this date
           type: date
-        with_original_date:
-          description: >
-            When the date of event has been changed by a schedule exception, original date is not
-            considered for date filtering (by from/to parameters). With this parameter Sirius will
-            include events’ original date in a date filter.
-          type: boolean
-          default: false
   - deletable:
       queryParameters:
         deleted:
@@ -83,6 +76,14 @@ resourceTypes:
   - events-collection:
       get:
         is: [ dateScoped, deletable, filterable, includable, paged, secured ]
+        queryParameters:
+          with_original_date:
+            description: >
+              When the date of event has been changed by a schedule exception, original date is not
+              considered for date filtering (by from/to parameters). With this parameter Sirius will
+              include events’ original date in a date filter.
+            type: boolean
+            default: false
         responses:
           200:
             body:
@@ -300,6 +301,85 @@ resourceTypes:
         Course code, faculty specific.
       required: true
       example: BI-PA1
+
+/faculties/{facultyId}:
+  uriParameters:
+    facultyId:
+      description: Faculty code (5 digits).
+      required: true
+      example: 18000
+  /schedule:
+    /days:
+      is: [ dateScoped ]
+      description: Get semester-related parameters for the specified days.
+      get:
+        responses:
+          200:
+            body:
+              application/json:
+      /{date}:
+        description: Get semester-related parameters for the specified day.
+        uriParameters:
+          date:
+            description: The date to resolve, or string `current` for the current day.
+            required: true
+            example: 2016-01-06
+        get:
+          responses:
+            200:
+              body:
+                application/json:
+                  example: |
+                    {
+                      "semester_days": {
+                        "date": "2016-01-06",
+                        "cwday": 3,
+                        "period_type": "teaching",
+                        "teaching_week": 13,
+                        "week_parity": "even",
+                        "links": {
+                          "semester": "18000-B151",
+                          "period": 8
+                        }
+                      }
+                    }
+    /weeks:
+      is: [ dateScoped ]
+      description: Get semester-related attributes of the specified weeks.
+      get:
+        responses:
+          200:
+            body:
+              application/json:
+      /{year_cweek}:
+        uriParameters:
+          year_cweek:
+            description: >
+              An ISO 8601 week-based year and week number of the week to resolve, or string
+              `current` for the current week.
+            required: true
+            example: 2015-52
+        get:
+          responses:
+            200:
+              body:
+                application/json:
+                  example: |
+                    {
+                      "semester_weeks": {
+                        "starts_at": "2015-12-21",
+                        "ends_at": "2015-12-27",
+                        "cweek": 52,
+                        "period_types": [ "teaching", "holiday" ],
+                        "teaching_week": 12,
+                        "week_parity": "even",
+                        "links": {
+                          "semester": "18000-B151",
+                          "periods": [ 5, 6, 7 ]
+                        }
+                      }
+                    }
+
 /schedule_exceptions:
   description: Manage schedule exceptions
   is: [ paged ]

--- a/lib/date_refinements.rb
+++ b/lib/date_refinements.rb
@@ -5,5 +5,10 @@ module DateRefinements
     def start_of_week
       self - self.cwday + 1  # cwday starts with 1 (Monday)
     end
+
+    # @return [Date] end of the week.
+    def end_of_week
+      self + 7 - self.cwday
+    end
   end
 end

--- a/lib/date_refinements.rb
+++ b/lib/date_refinements.rb
@@ -1,0 +1,9 @@
+module DateRefinements
+  refine ::Date do
+
+    # @return [Date] beginning of the week.
+    def start_of_week
+      self - self.cwday + 1  # cwday starts with 1 (Monday)
+    end
+  end
+end

--- a/lib/sirius_api/semester_day.rb
+++ b/lib/sirius_api/semester_day.rb
@@ -1,0 +1,82 @@
+require 'corefines'
+require 'day'
+require 'models/faculty_semester'
+
+module SiriusApi
+  class SemesterDay
+    using Corefines::Object::then
+
+    attr_reader :date, :semester
+
+    def initialize(semester, date)
+      @semester = semester.freeze
+      @date = date.freeze
+    end
+
+    # Finds FacultySemester that includes the specified date and returns
+    # an instance of SemesterDay that represents this date in context
+    # of the semester. If no semester for the date is found, then it returns nil.
+    def self.resolve(date, faculty_id)
+      FacultySemester
+        .find_by_date(date, faculty_id)
+        .then { |sem| new(sem, date) }
+    end
+
+    # Returns a Period that includes this date.
+    def period
+      @period ||= @semester.semester_periods.find do |p|
+        @date >= p.starts_at && @date <= p.ends_at
+      end
+    end
+
+    # Returns the day of calendar week (1-7, Monday is 1).
+    # It may not be the same as a real calendar day!
+    def cwday
+      return @date.cwday unless period.first_day_override
+
+      @cwday ||= begin
+        offset = Day.to_numeric(period.first_day_override) - period.starts_at.cwday
+        wday = @date.wday + offset
+        (wday - 1) % 7 + 1  # convert 0 to 7 (Sunday)
+      end
+    end
+
+    # Returns name of this day.
+    # @see #cwday
+    def wday_name
+      Day.from_numeric(cwday)
+    end
+
+    # Returns parity of this day (+:even+, or +:odd+), if it's inside a teaching
+    # period; otherwise returns nil.
+    def week_parity
+      return if period.type != :teaching
+
+      @week_parity ||= begin
+        first_parity = period.first_week_parity == :even ? 0 : 1
+        parity = (period.starts_at.cweek + @date.cweek + first_parity) % 2
+        parity == 0 ? :even : :odd
+      end
+    end
+
+    # Returns ordinal number of this week among weeks of the same type in
+    # the semester.
+    def week_num
+      @week_num ||= begin
+        periods = @semester.semester_periods
+          .find_all { |p| p.type == period.type && p.starts_at <= @date }
+          .sort_by(&:starts_at)
+
+        # Weeks is an array of calendar week numbers for each period,
+        # e.g. [10, 11, 13, 14]
+        weeks = periods.reduce([]) do |weeks, p|
+          weeks | (p.starts_at.cweek..p.ends_at.cweek).to_a
+        end
+
+        # Index in array corresponds to the semester week number, but starting
+        # from zero.
+        weeks.index(@date.cweek) + 1
+      end
+    end
+  end
+end

--- a/lib/sirius_api/semester_schedule.rb
+++ b/lib/sirius_api/semester_schedule.rb
@@ -1,0 +1,73 @@
+require 'faculty_semester'
+require 'sirius_api/semester_week'
+require 'date_refinements'
+
+module SiriusApi
+  module SemesterSchedule
+    using Corefines::Object::then
+    using ::DateRefinements
+
+    module_function
+
+    ##
+    # Returns semester weeks in the given range according to schedule of
+    # the specified faculty.
+    #
+    # @param start_date [Date] date of the first week to return (will be
+    #   rounded to the beginning of the week).
+    # @param end_date [Date] date of the last week to retun (will be rounded to
+    #   the beginning of the week).
+    # @param faculty_id [Fixnum] organizational number of the faculty.
+    # @return [Array<SemesterWeek>]
+    #
+    def resolve_weeks(start_date, end_date, faculty_id)
+      FacultySemester
+        .find_by_date_range_with_periods(start_date, end_date, faculty_id)
+        .flat_map do |sem|
+          SemesterWeek.resolve_weeks(sem, from: start_date.start_of_week, to: end_date)
+        end
+    end
+
+    ##
+    # Returns a semester week that occurs at the given date according to
+    # schedule of the specified faculty.
+    #
+    # @param date [Date]
+    # @param faculty_id (see #resolve_weeks)
+    # @return [SemesterWeek, nil] a semester week, or nil of no data.
+    #
+    def resolve_week(date, faculty_id)
+      resolve_weeks(date, date, faculty_id).first
+    end
+
+    ##
+    # Returns semester days in the given range according to schedule of
+    # the specified faculty.
+    #
+    # @param start_date [Date] date of the first day to return.
+    # @param end_date [Date] date of the last day to return.
+    # @param faculty_id (see #resolve_weeks)
+    # @return [Array<SemesterDay>]
+    #
+    def resolve_days(start_date, end_date, faculty_id)
+      resolve_weeks(start_date, end_date, faculty_id)
+        .flat_map(&:days)
+        .compact
+        .drop_while { |day| day.date < start_date }
+        .take_while { |day| day.date <= end_date }
+    end
+
+    ##
+    # Returns a semester day for the given date according to schedule of
+    # the specified faculty.
+    #
+    # @param date [Date] date of the day to return.
+    # @param faculty_id (see #resolve_weeks)
+    # @return [SemesterDay, nil] a semester day, or nil if no data.
+    #
+    def resolve_day(date, faculty_id)
+      resolve_week(date, faculty_id)
+        .then { |week| week.days[date.cwday - 1] }
+    end
+  end
+end

--- a/lib/sirius_api/semester_week.rb
+++ b/lib/sirius_api/semester_week.rb
@@ -1,0 +1,144 @@
+require 'corefines'
+require 'forwardable'
+require 'date_refinements'
+
+module SiriusApi
+  class SemesterWeek
+    extend Forwardable
+
+    using Corefines::Object::then
+    using Corefines::Enumerable::map_by
+    using ::DateRefinements
+
+    class << self
+      ##
+      # Generates {SemesterWeek}s for the given {FacultySemester}.
+      #
+      # @param semester [FacultySemester]
+      # @return [Array<SemesterWeek>] an array of semester weeks sorted by date.
+      #
+      def resolve_weeks(semester)
+        semester.semester_periods
+          .sort_by(&:starts_at)
+          .flat_map { |per| index_period_by_weeks per }
+          .map_by { |date, per| [date, per] }
+          .map { |date, pers| SemesterWeek.new(semester, pers, date) }
+          .sort_by(&:start_date)
+          .tap { |weeks| add_teaching_week_nums! weeks }
+      end
+
+      private
+
+      ##
+      # @example
+      #   <SemesterPeriod @starts_at="2016-01-07" @ends_at="2016-01-24">
+      #   #=> [
+      #         ["2016-01-04", <SemesterPeriod>],
+      #         ["2016-01-11", <SemesterPeriod>],
+      #         ["2016-01-18", <SemesterPeriod>]
+      #       ]
+      #
+      # @param period [SemesterPeriod]
+      # @return [Array] an array of two element arrays; the first element is
+      #   a Date that represents the beginning of a week and the second one is
+      #   the given period.
+      def index_period_by_weeks(period)
+        period.starts_at
+          .start_of_week
+          .step(period.ends_at, 7).to_a
+          .product([period])
+      end
+
+      ##
+      # Fills ordinal number (1-based) of a teaching week into each
+      # of the given {SemesterWeek} that contains a teaching period.
+      #
+      # @note This method mutates the given objects!
+      # @param weeks [Array<SemesterWeek>]
+      #
+      def add_teaching_week_nums!(weeks)
+        weeks
+          .select(&:teaching?)
+          .each_with_index do |o, i|
+            o.instance_variable_set(:@teaching_week, i + 1)
+          end
+      end
+    end
+
+    # @!attribute [r] cweek
+    #   @return [Fixnum] the calendar week number per ISO 8601 (1-53).
+    # @!attribute [r] cwyear
+    #   @return [Fixnum] the calendar week based year per ISO 8601.
+    def_delegators :@start_date, :cweek, :cwyear, :year
+
+    # @return [Array<SemesterPeriod>] an array of semester periods included or
+    #   intersecting this week.
+    attr_reader :periods
+
+    # @return [FacultySemester] the semester that contains this week.
+    attr_reader :semester
+
+    # @return [Date] the first day (monday) of this week.
+    attr_reader :start_date
+
+    # @return [Fixnum, nil] an ordinal number of the teaching week within the
+    #   semester, or `nil` if this week isn't inside a regular teaching period.
+    attr_reader :teaching_week
+
+    ##
+    # @param semester [FacultySemester] (see #semester)
+    # @param periods [Array<SemesterPeriod>] (see #periods)
+    # @param start_date [Date] (see #start_date)
+    # @param teaching_week [Fixnum, nil] (see #teaching_week)
+    def initialize(semester, periods, start_date, teaching_week = nil)
+      @semester = semester
+      @periods = periods.freeze
+      @start_date = start_date.freeze
+      @teaching_week = teaching_week
+    end
+
+    ##
+    # @return [Array<Symbol>] a set of regular period types within this week.
+    def period_types
+      @period_types ||= @periods.reject(&:irregular?).map(&:type).uniq.freeze
+    end
+
+    ##
+    # @return [Boolean] `true` if this week includes a regular teaching period,
+    #   `false` otherwise.
+    def teaching?
+      period_types.include? :teaching
+    end
+
+    ##
+    # Returns a parity of this week within a regular teaching semester period.
+    # If there's no such period, the method returns `nil`.
+    #
+    # The calculation is based on difference between the period's start date and
+    # and this week's date, shifted by the period's `first_week_parity`.
+    #
+    # @return [Symbol, nil] `:even`, `:odd`, or `nil`
+    #
+    def week_parity
+      return @week_parity if defined? @week_parity
+
+      @week_parity = @periods
+        .find { |p| p.regular? && p.teaching? }
+        .then do |period|
+          weeks_since_start = ((@start_date - period.starts_at.start_of_week) / 7).floor.abs
+          first_parity = period.first_week_parity == :even ? 0 : 1
+          parity = (weeks_since_start + first_parity) % 2
+
+          parity == 0 ? :even : :odd
+        end
+    end
+
+    def eql?(other)
+      %w[class periods semester start_date teaching_week].all? do |att|
+        other.send(att) == self.send(att)
+      end
+    end
+
+    alias_method :==, :eql?
+  end
+end

--- a/lib/sirius_api/validators.rb
+++ b/lib/sirius_api/validators.rb
@@ -1,1 +1,2 @@
 require 'sirius_api/validators/min'
+require 'sirius_api/validators/year_cweek'

--- a/lib/sirius_api/validators/year_cweek.rb
+++ b/lib/sirius_api/validators/year_cweek.rb
@@ -1,0 +1,25 @@
+require 'grape'
+
+module SiriusApi
+  module Validators
+    ##
+    # A Grape validator for date in format `%G-%V`; an ISO 8601 week-based year
+    # and a week number.
+    #
+    # @example How to use
+    #   params { requires :week, type: String, year_cweek: true }
+    #
+    class YearCweek < ::Grape::Validations::Validator
+
+      def validate_param!(attr_name, params)
+        value = params[attr_name]
+
+        unless value =~ /\A\d{4}-\d{1,2}\z/ && (Date.strptime(value, '%G-%V') rescue false)
+          raise Grape::Exceptions::Validation,
+            params: [@scope.full_name(attr_name)],
+            message: 'must be valid ISO 8601 week-based year and week number, e.g. 2016-42'
+        end
+      end
+    end
+  end
+end

--- a/spec/api/faculties_endpoints_spec.rb
+++ b/spec/api/faculties_endpoints_spec.rb
@@ -1,0 +1,239 @@
+require 'api_spec_helper'
+require 'api/faculties_endpoints'
+require 'sirius_api/semester_day'
+require 'sirius_api/semester_schedule'
+
+describe API::FacultiesEndpoints do
+  include_context 'API response'
+
+  let!(:faculty) { Fabricate(:faculty_semester).faculty }
+
+
+  describe 'GET /faculties/:code/schedule/days' do
+
+    let(:path) { "/faculties/#{faculty}/schedule/days" }
+    let(:from) { Date.today }  # default value
+    let(:to) { Date.today + 7 }  # default value
+    let(:json_type) { 'semester_days' }
+    let(:sem_days) { Fabricate.build_times(2, :semester_day) }
+
+    context 'existing faculty' do
+      before do
+        expect(SiriusApi::SemesterSchedule).to receive(:resolve_days)
+          .with(from, to, faculty).and_return(sem_days)
+      end
+
+      context 'with default from and to' do
+        it 'returns semester days from today to +7 days' do
+          get path_for(path)
+          expect( body ).to have_json_size(sem_days.size).at_path(json_type)
+        end
+      end
+
+      context 'with from and to' do
+        let(:from) { Date.today - 7 }
+        let(:to) { Date.today + 30 }
+
+        it 'returns semester days in the specified range' do
+          get path_for("#{path}?from=#{from}&to=#{to}")
+          expect( body ).to have_json_size(sem_days.size).at_path(json_type)
+        end
+      end
+    end
+
+    context 'non-existent faculty' do
+      let(:faculty) { 66006 }
+      let(:sem_days) { [] }
+
+      before { get path_for(path) }
+      it { should be_http_not_found }
+    end
+  end
+
+
+  describe 'GET /faculties/:code/schedule/days/:date' do
+
+    let(:path) { "/faculties/#{faculty}/schedule/days/#{date}" }
+    let(:sem_day) { Fabricate.build(:semester_day) }
+    let(:date) { sem_day.date }
+
+    let(:json) do
+      {
+        date: sem_day.date,
+        period_type: sem_day.period.type,
+        irregular: sem_day.irregular,
+        teaching_week: sem_day.teaching_week,
+        week_parity: sem_day.week_parity,
+        cwday: sem_day.cwday,
+        links: {
+          period: sem_day.period.id,
+          semester: "#{sem_day.semester.faculty}-#{sem_day.semester.code}"
+        }
+      }.to_json
+    end
+
+    before do
+      expect(SiriusApi::SemesterSchedule).to receive(:resolve_day)
+        .with(date, faculty).and_return(sem_day)
+    end
+
+    context 'existing faculty' do
+
+      context 'existing date' do
+        before { get path_for(path) }
+
+        it { should be_http_ok }
+        it { expect( body ).to be_json_eql(json).at_path('semester_days') }
+      end
+
+      context 'date "current"' do
+        let(:path) { "/faculties/#{faculty}/schedule/days/current" }
+        let(:date) { Date.today }
+
+        before { get path_for(path) }
+
+        it 'resolves SemesterDay for the current day' do
+          should be_http_ok
+        end
+
+        it { expect( body ).to be_json_eql(json).at_path('semester_days') }
+      end
+
+      context 'non-existent date' do
+        let(:sem_day) { nil }
+        let(:date) { Date.parse('2010-05-06') }
+
+        it_behaves_like 'non-existent resource'
+      end
+    end
+
+    context 'non-existent faculty' do
+      let(:sem_day) { nil }
+      let(:date) { Date.parse('2014-10-06') }
+
+      it_behaves_like 'non-existent resource'
+    end
+  end
+
+
+  describe 'GET /faculties/:code/schedule/weeks' do
+
+    let(:path) { "/faculties/#{faculty}/schedule/weeks" }
+    let(:from) { Date.today }  # default value
+    let(:to) { Date.today + 7 }  # default value
+    let(:json_type) { 'semester_weeks' }
+    let(:sem_weeks) { Fabricate.build_times(2, :semester_week) }
+
+    context 'existing faculty' do
+      before do
+        expect(SiriusApi::SemesterSchedule).to receive(:resolve_weeks)
+          .with(from, to, faculty).and_return(sem_weeks)
+      end
+
+      context 'with default from and to' do
+        it 'returns semester weeks from today to +7 days' do
+          get path_for(path)
+          expect( body ).to have_json_size(sem_weeks.size).at_path(json_type)
+        end
+      end
+
+      context 'with from and to' do
+        let(:from) { Date.today - 7 }
+        let(:to) { Date.today + 30 }
+
+        it 'returns semester weeks in the specified range' do
+          get path_for("#{path}?from=#{from}&to=#{to}")
+          expect( body ).to have_json_size(sem_weeks.size).at_path(json_type)
+        end
+      end
+    end
+
+    context 'non-existent faculty' do
+      let(:faculty) { 66006 }
+      let(:sem_weeks) { [] }
+
+      before { get path_for(path) }
+      it { should be_http_not_found }
+    end
+  end
+
+
+  describe 'GET /faculties/:code/schedule/weeks/:year_cweek' do
+
+    let(:path) { "/faculties/#{faculty}/schedule/weeks/#{year_cweek}" }
+    let(:sem_week) { Fabricate.build(:semester_week) }
+    let(:year_cweek) { "#{sem_week.cwyear}-#{sem_week.cweek}" }
+
+    let(:json) do
+      {
+        starts_at: sem_week.start_date,
+        ends_at: sem_week.end_date,
+        cweek: sem_week.cweek,
+        period_types: sem_week.period_types,
+        teaching_week: sem_week.teaching_week,
+        week_parity: sem_week.week_parity,
+        links: {
+          semester: "#{sem_week.semester.faculty}-#{sem_week.semester.code}",
+          periods: sem_week.periods.map(&:id)
+        }
+      }.to_json
+    end
+
+    context 'syntactically valid parameters' do
+
+      before do
+        date = Date.strptime(year_cweek, '%G-%V')
+        expect(SiriusApi::SemesterSchedule).to receive(:resolve_week)
+          .with(date, faculty).and_return(sem_week)
+      end
+
+      context 'existing faculty' do
+
+        context 'existing year-week' do
+          before { get path_for(path) }
+
+          it { should be_http_ok }
+          it { expect( body ).to be_json_eql(json).at_path('semester_weeks') }
+        end
+
+        context 'year-week "current"' do
+          let(:path) { "/faculties/#{faculty}/schedule/weeks/current" }
+          let(:year_cweek) { Date.today.strftime('%G-%V') }
+
+          before { get path_for(path) }
+
+          it 'resolves SemesterWeek for the current week' do
+            should be_http_ok
+          end
+
+          it { expect( body ).to be_json_eql(json).at_path('semester_weeks') }
+        end
+
+        context 'unknown year-week' do
+          let(:sem_week) { nil }
+          let(:year_cweek) { "2014-02" }
+
+          it_behaves_like 'non-existent resource'
+        end
+      end
+
+      context 'non-existent faculty' do
+        let(:faculty) { 66006 }
+        let(:sem_week) { nil }
+        let(:year_cweek) { "2014-45" }
+
+        it_behaves_like 'non-existent resource'
+      end
+    end
+
+    context 'syntactically invalid parameters' do
+
+      context 'invalid year_cweek' do
+        let(:year_cweek) { "2066-99" }
+
+        before { get path_for(path) }
+        it { should be_http_bad_request }
+      end
+    end
+  end
+end

--- a/spec/fabricators/faculty_semester_fabricator.rb
+++ b/spec/fabricators/faculty_semester_fabricator.rb
@@ -1,6 +1,7 @@
 require 'faculty_semester'
 
 Fabricator(:faculty_semester) do
+  id { sequence(:faculty_semester) }
   code 'B141'
   faculty 18000
   update_parallels true

--- a/spec/fabricators/semester_day_fabricator.rb
+++ b/spec/fabricators/semester_day_fabricator.rb
@@ -1,0 +1,8 @@
+require 'sirius_api/semester_day'
+
+Fabricator(:semester_day, class_name: SiriusApi::SemesterDay) do
+  initialize_with do
+    period = Fabricate(:teaching_semester_period)
+    SiriusApi::SemesterDay.new(period, Date.parse('2014-10-01'), 2)
+  end
+end

--- a/spec/fabricators/semester_period_fabricator.rb
+++ b/spec/fabricators/semester_period_fabricator.rb
@@ -1,6 +1,7 @@
 require 'models/semester_period'
 
 Fabricator(:semester_period) do
+  id { sequence(:semester_period) }
   faculty_semester
   type :teaching
   irregular false

--- a/spec/fabricators/semester_week_fabricator.rb
+++ b/spec/fabricators/semester_week_fabricator.rb
@@ -1,0 +1,20 @@
+require 'sirius_api/semester_week'
+require 'date_refinements'
+
+using DateRefinements
+
+Fabricator(:semester_week, class_name: SiriusApi::SemesterWeek) do
+  initialize_with do
+    period = Fabricate(:teaching_semester_period)
+    SiriusApi::SemesterWeek.new(period.faculty_semester, [period],
+        period.starts_at.start_of_week, 1)
+  end
+end
+
+Fabricator(:semester_week_2, class_name: SiriusApi::SemesterWeek) do
+  initialize_with do
+    period = Fabricate(:teaching_semester_period)
+    SiriusApi::SemesterWeek.new(period.faculty_semester, [period],
+        period.starts_at.start_of_week + 7, 2)
+  end
+end

--- a/spec/lib/date_refinements_spec.rb
+++ b/spec/lib/date_refinements_spec.rb
@@ -20,4 +20,19 @@ describe DateRefinements do
       end
     end
   end
+
+  describe '#end_of_week' do
+
+    where :date    , :expected do
+      '2016-01-01' | '2016-01-03'
+      '2016-01-10' | '2016-01-10'
+      '2016-03-07' | '2016-03-13'
+    end
+
+    with_them ->{ date } do
+      it "returns #{row.expected}" do
+        expect( Date.parse(date).end_of_week ).to eq Date.parse(expected)
+      end
+    end
+  end
 end

--- a/spec/lib/date_refinements_spec.rb
+++ b/spec/lib/date_refinements_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'rspec-parameterized'
+require 'date_refinements'
+
+describe DateRefinements do
+  using RSpec::Parameterized::TableSyntax
+  using described_class
+
+  describe '#start_of_week' do
+
+    where :date    , :expected do
+      '2016-01-01' | '2015-12-28'
+      '2016-01-04' | '2016-01-04'
+      '2016-03-13' | '2016-03-07'
+    end
+
+    with_them ->{ date } do
+      it "returns #{row.expected}" do
+        expect( Date.parse(date).start_of_week ).to eq Date.parse(expected)
+      end
+    end
+  end
+end

--- a/spec/lib/sirius_api/semester_day_spec.rb
+++ b/spec/lib/sirius_api/semester_day_spec.rb
@@ -1,0 +1,143 @@
+require 'spec_helper'
+require 'sirius_api/semester_day'
+require 'rspec-parameterized'
+
+module SiriusApi
+describe SemesterDay do
+
+  using RSpec::Parameterized::TableSyntax
+
+  let(:semester) do
+    Fabricate.build :faculty_semester,
+      id: 123,
+      code: 'B151',
+      faculty: 99000,
+      starts_at: '2015-10-05',
+      ends_at: '2016-02-21',
+      semester_periods: semester_periods
+  end
+
+  let(:semester_periods) do
+    [# type,      starts_at,    ends_at,      parity, day_override
+      [:teaching, '2015-10-05', '2015-12-07', :odd,   nil],
+      [:teaching, '2015-12-08', '2015-12-09', :odd,   :thursday],
+      [:teaching, '2015-12-10', '2015-12-21', :even,  nil],
+      [:teaching, '2015-12-22', '2015-12-22', :odd,   nil],
+      [:holiday,  '2015-12-23', '2016-01-03', nil,    nil],
+      [:teaching, '2016-01-04', '2016-01-10', :even,  nil],
+      [:exams,    '2016-01-11', '2016-02-21', nil,    nil]
+    ].map do |row|
+      Fabricate.build :semester_period,
+        type: row[0],
+        starts_at: row[1],
+        ends_at: row[2],
+        first_week_parity: row[3],
+        first_day_override: row[4]
+    end
+  end
+
+  subject(:sem_day) { described_class.new(semester, date) }
+  let(:date) { Date.parse '2015-12-11' }
+
+
+  describe '.resolve' do
+
+    subject { described_class.resolve(date, faculty) }
+    let(:faculty) { 18000 }
+
+    before do
+      expect(FacultySemester).to receive(:find_by_date)
+        .with(date, faculty).and_return(semester)
+    end
+
+    context 'unknown faculty or date' do
+      let(:semester) { nil }
+      it { should be_nil }
+    end
+
+    context 'valid arguments' do
+      it { should be_instance_of SemesterDay }
+
+      it 'finds semester for the given date' do
+        expect( subject.semester ).to eq semester
+      end
+    end
+  end
+
+  describe '#date' do
+    it 'returns frozen object' do
+      expect( sem_day.date.frozen? ).to be true
+    end
+  end
+
+  describe '#semester' do
+    it 'returns frozen object' do
+      expect( sem_day.semester.frozen? ).to be true
+    end
+  end
+
+  describe '#period' do
+    it 'returns correct period' do
+      expect( sem_day.period ).to eq semester_periods[2]
+    end
+  end
+
+  describe '#cwday/#wday_name' do
+
+    context 'for normal day' do
+      it "returns a calendar week day" do
+        expect( sem_day.cwday ).to eq 5
+        expect( sem_day.wday_name ).to eq :friday
+      end
+    end
+
+    context 'for date affected by first_day_override' do
+      let(:date) { Date.parse '2015-12-08' }
+
+      it 'returns a week day shifted by first_day_override' do
+        expect( sem_day.cwday ).to eq 4
+        expect( sem_day.wday_name ).to eq :thursday
+      end
+    end
+  end
+
+  describe '#week_parity' do
+
+    where :tdate   , :expected, :desc do
+      '2015-10-05' | :odd     | 'first day of teaching period'
+      '2015-10-12' | :even    | 'day a week after start of teaching period'
+      '2015-12-08' | :odd     | 'first day of new teaching period with flipped parity'
+      '2016-01-10' | :even    | 'last day of last teaching period'
+      '2015-12-24' | nil      | 'holiday period'
+      '2016-01-12' | nil      | 'exams period'
+    end
+
+    with_them ->{ desc } do
+      let(:date) { Date.parse tdate }
+
+      it 'returns correct parity' do
+        expect( sem_day.week_parity ).to eq expected
+      end
+    end
+  end
+
+  describe '#week_num' do
+
+    where :tdate   , :expected, :desc do
+      '2015-10-05' | 1        | 'first day of first teaching period'
+      '2015-12-22' | 12       | 'day before holiday in same week'
+      '2015-12-23' | 1        | 'first day of holiday after teaching period'
+      '2016-01-04' | 13       | 'week in a teaching period after holidays'
+      '2016-01-24' | 2        | 'second week of exams period'
+    end
+
+    with_them ->{ desc } do
+      let(:date) { Date.parse tdate }
+
+      it 'returns correct week number' do
+        expect( sem_day.week_num ).to eq expected
+      end
+    end
+  end
+end
+end

--- a/spec/lib/sirius_api/semester_day_spec.rb
+++ b/spec/lib/sirius_api/semester_day_spec.rb
@@ -1,143 +1,58 @@
 require 'spec_helper'
 require 'sirius_api/semester_day'
-require 'rspec-parameterized'
 
 module SiriusApi
 describe SemesterDay do
 
-  using RSpec::Parameterized::TableSyntax
+  subject(:sem_day) { described_class.new(period, date, 1) }
+  let(:date) { Date.new(2015, 11, 11) }
+  let(:first_day_override) { nil }
 
-  let(:semester) do
-    Fabricate.build :faculty_semester,
-      id: 123,
-      code: 'B151',
-      faculty: 99000,
-      starts_at: '2015-10-05',
-      ends_at: '2016-02-21',
-      semester_periods: semester_periods
-  end
-
-  let(:semester_periods) do
-    [# type,      starts_at,    ends_at,      parity, day_override
-      [:teaching, '2015-10-05', '2015-12-07', :odd,   nil],
-      [:teaching, '2015-12-08', '2015-12-09', :odd,   :thursday],
-      [:teaching, '2015-12-10', '2015-12-21', :even,  nil],
-      [:teaching, '2015-12-22', '2015-12-22', :odd,   nil],
-      [:holiday,  '2015-12-23', '2016-01-03', nil,    nil],
-      [:teaching, '2016-01-04', '2016-01-10', :even,  nil],
-      [:exams,    '2016-01-11', '2016-02-21', nil,    nil]
-    ].map do |row|
-      Fabricate.build :semester_period,
-        type: row[0],
-        starts_at: row[1],
-        ends_at: row[2],
-        first_week_parity: row[3],
-        first_day_override: row[4]
-    end
-  end
-
-  subject(:sem_day) { described_class.new(semester, date) }
-  let(:date) { Date.parse '2015-12-11' }
-
-
-  describe '.resolve' do
-
-    subject { described_class.resolve(date, faculty) }
-    let(:faculty) { 18000 }
-
-    before do
-      expect(FacultySemester).to receive(:find_by_date)
-        .with(date, faculty).and_return(semester)
-    end
-
-    context 'unknown faculty or date' do
-      let(:semester) { nil }
-      it { should be_nil }
-    end
-
-    context 'valid arguments' do
-      it { should be_instance_of SemesterDay }
-
-      it 'finds semester for the given date' do
-        expect( subject.semester ).to eq semester
-      end
-    end
+  let(:period) do
+    Fabricate.build :semester_period,
+      type: :teaching,
+      starts_at: '2015-11-11',
+      ends_at: '2015-11-27',
+      first_week_parity: :odd,
+      first_day_override: first_day_override
   end
 
   describe '#date' do
-    it 'returns frozen object' do
-      expect( sem_day.date.frozen? ).to be true
-    end
+    it { expect( sem_day.date ).to be_frozen }
   end
 
   describe '#semester' do
-    it 'returns frozen object' do
-      expect( sem_day.semester.frozen? ).to be true
-    end
-  end
-
-  describe '#period' do
-    it 'returns correct period' do
-      expect( sem_day.period ).to eq semester_periods[2]
+    it "returns period's faculty_semester" do
+      expect( sem_day.semester ).to be period.faculty_semester
     end
   end
 
   describe '#cwday/#wday_name' do
 
-    context 'for normal day' do
+    context 'normal day' do
       it "returns a calendar week day" do
-        expect( sem_day.cwday ).to eq 5
-        expect( sem_day.wday_name ).to eq :friday
+        expect( sem_day.cwday ).to eq 3
+        expect( sem_day.wday_name ).to eq :wednesday
       end
     end
 
-    context 'for date affected by first_day_override' do
-      let(:date) { Date.parse '2015-12-08' }
+    context 'date affected by first_day_override' do
+      let(:first_day_override) { :tuesday }
 
       it 'returns a week day shifted by first_day_override' do
-        expect( sem_day.cwday ).to eq 4
-        expect( sem_day.wday_name ).to eq :thursday
+        expect( sem_day.cwday ).to eq 2
+        expect( sem_day.wday_name ).to eq :tuesday
       end
     end
   end
 
   describe '#week_parity' do
 
-    where :tdate   , :expected, :desc do
-      '2015-10-05' | :odd     | 'first day of teaching period'
-      '2015-10-12' | :even    | 'day a week after start of teaching period'
-      '2015-12-08' | :odd     | 'first day of new teaching period with flipped parity'
-      '2016-01-10' | :even    | 'last day of last teaching period'
-      '2015-12-24' | nil      | 'holiday period'
-      '2016-01-12' | nil      | 'exams period'
-    end
-
-    with_them ->{ desc } do
-      let(:date) { Date.parse tdate }
-
-      it 'returns correct parity' do
-        expect( sem_day.week_parity ).to eq expected
-      end
+    it 'returns result of @period.week_parity(@date)' do
+      expect( sem_day.period ).to receive(:week_parity).with(date).and_return(:odd)
+      expect( sem_day.week_parity ).to eq :odd
     end
   end
 
-  describe '#week_num' do
-
-    where :tdate   , :expected, :desc do
-      '2015-10-05' | 1        | 'first day of first teaching period'
-      '2015-12-22' | 12       | 'day before holiday in same week'
-      '2015-12-23' | 1        | 'first day of holiday after teaching period'
-      '2016-01-04' | 13       | 'week in a teaching period after holidays'
-      '2016-01-24' | 2        | 'second week of exams period'
-    end
-
-    with_them ->{ desc } do
-      let(:date) { Date.parse tdate }
-
-      it 'returns correct week number' do
-        expect( sem_day.week_num ).to eq expected
-      end
-    end
-  end
 end
 end

--- a/spec/lib/sirius_api/semester_schedule_spec.rb
+++ b/spec/lib/sirius_api/semester_schedule_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+require 'sirius_api/semester_schedule'
+
+module SiriusApi
+  describe SemesterSchedule do
+
+    let(:semester_weeks) { [ Fabricate.build(:semester_week) ] }
+    let(:start_date) { semester_weeks.first.start_date + 1 }  # Tuesday
+    let(:end_date) { semester_weeks.last.end_date - 3 }  # Thursday
+    let(:faculty_id) { 18000 }
+
+    let(:first_day) do
+      semester_weeks.flat_map(&:days).find { |day| day.date == start_date }
+    end
+
+    before do
+      expect(described_class).to receive(:resolve_weeks)
+        .with(start_date, end_date, faculty_id)
+        .and_return(semester_weeks)
+    end
+
+
+    describe '#resolve_week' do
+      subject(:actual) { described_class.resolve_week(start_date, faculty_id) }
+      let(:end_date) { start_date }
+
+      context 'known date' do
+        it 'returns SemesterWeek that contains the specified date' do
+          expect( actual ).to eq semester_weeks.first
+        end
+      end
+
+      context 'unknown date' do
+        let(:semester_weeks) { [] }
+        let(:start_date) { Date.parse('2020-06-06') }
+        it { should be nil }
+      end
+    end
+
+
+    describe '#resolve_days' do
+      subject(:actual) do
+        described_class.resolve_days(start_date, end_date, faculty_id)
+      end
+
+      it 'returns an array of SemesterDays' do
+        expect( actual ).to be_instance_of Array
+        expect( actual.first ).to eq first_day
+      end
+
+      context 'with range covering single week' do
+        it 'returns days in the given range' do
+          expect( actual.map(&:date) ).to eq start_date.step(end_date).to_a
+        end
+      end
+
+      context 'with range covering multiple weeks' do
+        let(:semester_weeks) { [
+          Fabricate.build(:semester_week), Fabricate.build(:semester_week_2)
+        ] }
+
+        it 'returns days in the given range' do
+          expect( actual.map(&:date) ).to eq start_date.step(end_date).to_a
+        end
+      end
+    end
+
+
+    describe '#resolve_day' do
+      subject(:actual) { described_class.resolve_day(start_date, faculty_id) }
+      let(:end_date) { start_date }
+
+      context 'known date' do
+        it 'returns correct SemesterDay' do
+          expect( actual ).to eq first_day
+        end
+      end
+
+      context 'unknown date' do
+        let(:semester_weeks) { [] }
+        let(:start_date) { Date.parse('2020-06-06') }
+        it { should be nil }
+      end
+    end
+  end
+end

--- a/spec/lib/sirius_api/semester_week_spec.rb
+++ b/spec/lib/sirius_api/semester_week_spec.rb
@@ -75,6 +75,35 @@ describe SiriusApi::SemesterWeek do
     it { should be_frozen }
   end
 
+  describe '#days' do
+    subject(:days) { semester_week.days }
+    let(:semester_week) { semester_weeks[5] }
+
+    it { should be_frozen }
+
+    it 'returns days with correct period' do
+      expected = ([4] * 3 + [5] * 4).map { |idx| semester_periods[idx] }
+      expect( days.map(&:period) ).to eq expected
+    end
+
+    it 'returns days with correct date' do
+      expected = (4..10).map { |d| Date.parse("2016-01-#{d}") }
+      expect( days.map(&:date) ).to eq expected.to_a
+    end
+
+    it 'returns days with the same teaching_week as this week' do
+      expect( days.map(&:teaching_week).uniq ).to eq [4]
+    end
+  end
+
+  describe '#end_date' do
+    let(:semester_week) { semester_weeks[0] }
+
+    it 'returns date of the last day of the week' do
+      expect( semester_week.end_date ).to eq Date.parse('2015-12-06')
+    end
+  end
+
   describe '#period_types' do
     subject { semester_week.period_types }
 
@@ -137,20 +166,6 @@ describe SiriusApi::SemesterWeek do
 
       it 'returns correct parity' do
         should eq expected
-      end
-    end
-
-    context 'week of a teaching period that intersects a year' do
-      let(:week_period) do
-        Fabricate.build :semester_period,
-          type: :teaching,
-          starts_at: '2015-12-23', ends_at: '2016-01-10',
-          first_week_parity: :even
-      end
-      let(:semester_week) { described_class.new(semester, [week_period], Date.parse('2016-01-05')) }
-
-      it 'returns correct parity' do
-        should eq :even
       end
     end
   end

--- a/spec/lib/sirius_api/semester_week_spec.rb
+++ b/spec/lib/sirius_api/semester_week_spec.rb
@@ -1,0 +1,157 @@
+require 'spec_helper'
+require 'corefines'
+require 'rspec-parameterized'
+require 'sirius_api/semester_week'
+
+describe SiriusApi::SemesterWeek do
+  using Corefines::Enumerable::index_by
+  using RSpec::Parameterized::TableSyntax
+
+  let(:semester) do
+    Fabricate.build :faculty_semester,
+      id: 123,
+      code: 'B151',
+      faculty: 99000,
+      starts_at: '2015-10-05',
+      ends_at: '2016-02-21',
+      semester_periods: semester_periods
+  end
+
+  # This is input for the .resolve_weeks method.
+  let(:semester_periods) do
+    [# type     , starts_at   , ends_at     , parity, day_override, irregular # semester_week_idx
+      [:teaching, '2015-12-03', '2015-12-20', :odd  , nil         , false],   # 0-2
+      [:teaching, '2015-12-21', '2015-12-21', :even , :wednesday  , true ],   # 3
+      [:teaching, '2015-12-22', '2015-12-22', :odd  , :tuesday    , true ],   # 3
+      [:holiday , '2015-12-23', '2016-01-03', nil   , nil         , false],   # 3-4
+      [:teaching, '2016-01-04', '2016-01-06', :odd  , nil         , false],   # 5
+      [:exams   , '2016-01-07', '2016-01-15', nil   , nil         , false]    # 5-6
+    ].map do |row|
+      Fabricate.build :semester_period,
+        type: row[0],
+        starts_at: row[1],
+        ends_at: row[2],
+        first_week_parity: row[3],
+        first_day_override: row[4],
+        irregular: row[5]
+    end
+  end
+
+  # This is what the .resolve_weeks method should produce.
+  let(:semester_weeks) do
+    [# start_date  , periods, teaching_week
+      ['2015-11-30', 0      , 1  ],  # 0
+      ['2015-12-07', 0      , 2  ],  # 1
+      ['2015-12-14', 0      , 3  ],  # 2
+      ['2015-12-21', (1..3) , nil],  # 3
+      ['2015-12-28', 3      , nil],  # 4
+      ['2016-01-04', (4..5) , 4  ],  # 5
+      ['2016-01-11', 5      , nil]   # 6
+    ].map { |(start_date, periods, teaching_week)|
+      periods = Array(periods).map { |idx| semester_periods[idx] }
+      described_class.new(semester, periods, Date.parse(start_date), teaching_week)
+    }
+  end
+
+  subject(:semester_week) { semester_weeks[0] }
+
+
+  describe '.resolve_weeks' do
+    subject(:actual) { described_class.resolve_weeks(semester) }
+
+    it 'returns resolved semester weeks' do
+      expect( actual.map(&:start_date) ).to eq semester_weeks.map(&:start_date)
+      expect( actual ).to eq semester_weeks
+    end
+  end
+
+  describe '#periods' do
+    subject { semester_week.periods }
+    it { should be_frozen }
+  end
+
+  describe '#start_date' do
+    subject { semester_week.start_date }
+    it { should be_frozen }
+  end
+
+  describe '#period_types' do
+    subject { semester_week.period_types }
+
+    it { should be_frozen }
+
+    context 'week contains multiple regular periods' do
+      let(:semester_week) { semester_weeks[5] }
+
+      it 'returns types of all the periods' do
+        should eq [:teaching, :exams]
+      end
+
+      context 'of the same type' do
+        let(:week_periods) { semester_periods[1..3].each { |p| p.irregular = false } }
+        let(:semester_week) { described_class.new(semester, week_periods, Date.parse('2015-12-21')) }
+
+        it 'returns deduplicated types' do
+          should eq [:teaching, :holiday]
+        end
+      end
+    end
+
+    context 'week contains regular and irregular periods' do
+      let(:semester_week) { semester_weeks[3] }
+
+      it 'returns only types of regular periods' do
+        should eq [:holiday]
+      end
+    end
+  end
+
+  describe '#teaching?' do
+
+    where :week_idx, :expected, :desc do
+      5 | true  | 'a regular teaching period'
+      3 | false | 'only irregular teaching periods'
+      4 | false | 'no teaching period'
+    end
+
+    with_them ->{ "week includes #{desc}" } do
+      subject { semester_weeks[week_idx].teaching? }
+      it { should eq expected }
+    end
+  end
+
+  describe '#week_parity' do
+    subject { semester_week.week_parity }
+
+    where :week_idx, :expected, :desc do
+      0 | :odd  | 'first week of a teaching period'
+      1 | :even | 'week after start of a teaching period'
+      5 | :odd  | 'first week of a second teaching period'
+      3 | nil   | 'week with only irregular teaching periods'
+      4 | nil   | 'week inside a holiday period'
+      6 | nil   | 'week inside an exams period'
+    end
+
+    with_them ->{ desc } do
+      let(:semester_week) { semester_weeks[week_idx] }
+
+      it 'returns correct parity' do
+        should eq expected
+      end
+    end
+
+    context 'week of a teaching period that intersects a year' do
+      let(:week_period) do
+        Fabricate.build :semester_period,
+          type: :teaching,
+          starts_at: '2015-12-23', ends_at: '2016-01-10',
+          first_week_parity: :even
+      end
+      let(:semester_week) { described_class.new(semester, [week_period], Date.parse('2016-01-05')) }
+
+      it 'returns correct parity' do
+        should eq :even
+      end
+    end
+  end
+end

--- a/spec/lib/sirius_api/validators/year_cweek_spec.rb
+++ b/spec/lib/sirius_api/validators/year_cweek_spec.rb
@@ -1,0 +1,36 @@
+require 'api_spec_helper'
+require 'sirius_api/validators/year_cweek'
+
+describe SiriusApi::Validators::YearCweek do
+
+  module YearCweekSpec
+    class API < Grape::API
+      default_format :json
+      params { requires :cweek, year_cweek: true }
+      get {}
+    end
+  end
+
+  def app
+    YearCweekSpec::API
+  end
+
+  context 'invalid input' do
+    it 'refuses non-existent week number' do
+      get '/', cweek: '2000-99'
+      expect(last_response.status).to eq 400
+    end
+
+    it 'refuses invalid format' do
+      get '/', cweek: '99-22'
+      expect(last_response.status).to eq 400
+    end
+  end
+
+  context 'valid input' do
+    it 'accepts valid year-cweek' do
+      get '/', cweek: '2016-42'
+      expect(last_response.status).to eq 200
+    end
+  end
+end

--- a/spec/models/semester_period_spec.rb
+++ b/spec/models/semester_period_spec.rb
@@ -1,10 +1,12 @@
 require 'spec_helper'
 require 'models/semester_period'
+require 'rspec-parameterized'
 
 describe SemesterPeriod do
+  using RSpec::Parameterized::TableSyntax
 
-  let(:starts_at) { Date.new(2015, 10, 6) }
-  let(:ends_at) { Date.new(2015, 12, 20) }
+  let(:starts_at) { Date.new(2015, 11, 11) }
+  let(:ends_at) { Date.new(2016, 1, 13) }
   let(:type) { :teaching }
   let(:parity) { :odd }
 
@@ -62,6 +64,58 @@ describe SemesterPeriod do
       let(:parity) { nil }
       it 'can be nullable' do
         expect(period.save.reload.first_week_parity).to be nil
+      end
+    end
+  end
+
+  describe '#include?' do
+
+    context 'date in the range' do
+      it 'returns true' do
+        [starts_at, starts_at + 1, ends_at].each do |date|
+          expect( period.include? date ).to be true
+        end
+      end
+    end
+
+    context 'date out of the range' do
+      it 'returns false' do
+        [starts_at - 1, ends_at + 1].each do |date|
+          expect( period.include? date ).to be false
+        end
+      end
+    end
+  end
+
+  describe '#week_parity' do
+    let(:date) { Date.new(2015, 11, 13) }
+    subject { period.week_parity(date) }
+
+    context 'non-teaching period' do
+      let(:type) { :exams }
+      it { should be nil }
+    end
+
+    context 'date out of period' do
+      ['2015-11-05', '2015-11-08', '2016-01-18', '2016-11-14'].each do |date|
+        it "raises ArgumentError (#{date})" do
+          expect { period.week_parity(Date.parse(date)) }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    where :tdate   , :expected, :desc do
+      '2015-11-11' | :odd     | 'first day of the period'
+      '2015-11-09' | :odd     | 'date within the first week of the period, but before starts_at'
+      '2015-12-01' | :even    | 'date in the fourth week of the period'
+      '2016-01-07' | :odd     | 'date in the next year of the period'
+    end
+
+    with_them ->{ desc } do
+      let(:date) { Date.parse(tdate) }
+
+      it 'returns correct parity' do
+        should eq expected
       end
     end
   end

--- a/spec/models/semester_period_spec.rb
+++ b/spec/models/semester_period_spec.rb
@@ -7,9 +7,23 @@ describe SemesterPeriod do
   let(:ends_at) { Date.new(2015, 12, 20) }
   let(:type) { :teaching }
   let(:parity) { :odd }
-  subject(:period) {
+
+  subject(:period) do
     described_class.new(starts_at: starts_at, ends_at: ends_at, type: type, first_week_parity: parity)
-  }
+  end
+
+  describe '#teaching?' do
+    subject { period.teaching? }
+
+    context 'teaching period' do
+      it { should be true }
+    end
+
+    context 'non-teaching period' do
+      let(:type) { :exams }
+      it { should be false }
+    end
+  end
 
   describe '#validate' do
     context 'ends_at before starts_at' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ end
 
 require 'rspec'
 require 'rspec/collection_matchers'
+require 'rspec/http'
 require 'fabrication'
 
 require 'dotenv'

--- a/spec/support/be_frozen_matcher.rb
+++ b/spec/support/be_frozen_matcher.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :be_frozen do
+  match do |actual|
+    expect( actual.frozen? ).to be(true), 'expected frozen object'
+  end
+end


### PR DESCRIPTION
I’ve implemented an algorithm for resolving week number, parity, … from the given date, and also added API resource. It’s functional, but there are no tests yet and everything may be changed.

@jnv @flexik What do you think?

### TODO (new)

- [x] Design RESTful API.
- [x] Allow to filter date from–to in `SemesterWeek` and `SemesterDate`.
- ~~[ ] Add support for compound resources.~~ (in another PR)
- [x] Write missing tests.