### PR TITLE
Fix missing events with parity oposite to corresponding period

### DIFF
--- a/app/roles/planned_semester_period.rb
+++ b/app/roles/planned_semester_period.rb
@@ -1,5 +1,6 @@
 require 'role_playing'
 require 'ice_cube'
+require 'active_support/core_ext/date/calculations'  # next_week
 
 require 'period'
 require 'day'
@@ -7,8 +8,10 @@ require 'day'
 class PlannedSemesterPeriod < RolePlaying::Role
 
   def plan(teaching_time)
-    week_offset = teaching_time.week_offset(first_week_parity)
-    scheduling_start = combine_date_with_time(starts_at, teaching_time.starts_at) + week_offset
+    scheduling_start = combine_date_with_time(
+      schedule_start_day(teaching_time.parity),
+      teaching_time.starts_at
+    )
 
     schedule = IceCube::Schedule.new(scheduling_start, duration: teaching_time.duration)
     schedule.add_recurrence_rule teaching_time.to_recurrence_rule(day_offset, ends_at)
@@ -28,5 +31,13 @@ class PlannedSemesterPeriod < RolePlaying::Role
 
   def combine_date_with_time(date, time)
     Time.new(date.year, date.month, date.day, time.hour, time.min, time.sec)
+  end
+
+  def schedule_start_day(teaching_time_parity)
+    if teaching_time_parity == :both || teaching_time_parity == first_week_parity
+      starts_at
+    else
+      starts_at.next_week(:monday)
+    end
   end
 end

--- a/lib/sirius/teaching_time.rb
+++ b/lib/sirius/teaching_time.rb
@@ -12,14 +12,6 @@ module Sirius
       @parity = parity
     end
 
-    def week_offset(starting_week_parity)
-      if @parity == :both || @parity == starting_week_parity
-        0.weeks
-      else
-        1.week
-      end
-    end
-
     def starts_at
       @teaching_period.starts_at
     end

--- a/spec/roles/planned_semester_period_spec.rb
+++ b/spec/roles/planned_semester_period_spec.rb
@@ -55,6 +55,20 @@ describe PlannedSemesterPeriod do
     end
   end
 
+  context 'with period beginning in the middle of a week' do
+    # even period starting on Wednesday
+    subject(:period) { create_period('9.12.2015', '20.12.2015') }
+
+    context 'with events having different parity than starting week' do
+      it 'plans occurrences on second week correctly' do
+        teaching_time.parity = :odd
+        events = period.plan(teaching_time)
+        # odd event should be planned once on following Tuesday (2015-12-15)
+        expect(events).to contain_exactly(Period.parse('15.12.2015 14:30', '15.12.2015 16:00'))
+      end
+    end
+  end
+
   it 'returns two Time instances in Period' do
     event = period.plan(teaching_time).first
     expect(event.starts_at).to be_an_instance_of(Time)


### PR DESCRIPTION
This PR fixes #177.

The reason for missing events was incorrect calculation of period beginning for events with opposite parity to relevant semester period. Only periods with starting dates not on Mondays were affected.