### PR TITLE
Fix invalid UUID queries in specs

### DIFF
--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -25,7 +25,7 @@ describe Person do
     end
 
     it 'returns nil for malformed UUID' do
-      expect(Person.id_from_token('123-456-666')).to be_nil
+      expect(Person.id_from_token('11111111-1111-1111-9999-888888888888')).to be_nil
     end
   end
 end

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -16,7 +16,7 @@ describe Token do
     end
     context 'for invalid token format' do
       it 'returns nil' do
-        expect(Token.authenticate('meh')).to be_nil
+        expect(Token.authenticate('11111111-1111-1111-9999-888888888888')).to be_nil
       end
     end
   end


### PR DESCRIPTION
DB rejects these queries prior to executing them, so they silently pass without actually searching table.