### PR TITLE
Travis: Postgres 9.5 & Elastic 1.7 in trusty container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,29 @@
 language: ruby
 sudo: false
+dist: trusty
+addons:
+  postgresql: '9.5'
+  apt:
+    sources:
+      - elasticsearch-1.7
+    packages:
+      - elasticsearch
+  code_climate:
+    repo_token: a813ce884be14a158262d4e05906c0b6f4e7f4533c41cdf88bda7da84d88297f
 cache:
   bundler: true
 rvm:
   - 2.2.6
   - 2.3.1
   - ruby-head
-addons:
-  postgresql: '9.4'
-  code_climate:
-    repo_token: a813ce884be14a158262d4e05906c0b6f4e7f4533c41cdf88bda7da84d88297f
 services:
+  - postgresql
   - elasticsearch
 bundler_args: --without development doc
-before_install:
-  - gem update --system  # https://github.com/vcr/vcr/issues/582
 before_script:
   - while read line; do export $line; done < .env.test
   - bundle exec rake --trace db:setup
+  - echo 'waiting for elasticsearch to come up'; wget -q --waitretry=1 --retry-connrefused -T 10 -O - http://127.0.0.1:9200
 after_success: |
   if [ "$TRAVIS_BRANCH" = master ]; then
       nvm install 4.2 && nvm use 4.2 \


### PR DESCRIPTION
- Use container-based trusty w/ native postgres 9.5
- Install Elasticsearch 1.7 via official repository