### PR TITLE
Bump MRI dependencies to 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,4 @@ matrix:
   fast_finish: true
   allow_failures:
     - rvm: ruby-head
+    - rvm: 2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ addons:
 cache:
   bundler: true
 rvm:
-  - 2.2.6
-  - 2.3.1
+  - 2.3
+  - 2.4
   - ruby-head
 services:
   - postgresql

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 unless ENV['CI']
-  ruby '2.2.6'
+  ruby '~> 2.3.4'
 end
 
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -392,6 +392,7 @@ DEPENDENCIES
   warden (~> 1.2.3)
 
 RUBY VERSION
-   ruby 2.2.6p396
+   ruby 2.3.4p301
+
 BUNDLED WITH
-   1.14.2
+   1.14.6


### PR DESCRIPTION
- Lock Ruby requirement in Gemfile only for minor version
- Travis: Test against latest 2.3 and 2.4 series