### PR TITLE
Enum plugin overhauling

### DIFF
--- a/lib/sequel/plugins/enum.rb
+++ b/lib/sequel/plugins/enum.rb
@@ -7,7 +7,6 @@ module Sequel
     #
     # When enabled on model's field, the plugin:
     # - loads possible enum values from model's schema,
-    # - converts field's value to symbol,
     # - prevents setting incorrect value on field,
     # - exposes known enum fields and values in `.enums` class method.
     #
@@ -26,8 +25,8 @@ module Sequel
     #     instance.column1 = 'a'  # Values can be set both as symbols or strings
     #     instance.column2 = :c
     #
-    #     instance.column1        # Field's value is returned as symbol
-    #     #=> :a
+    #     instance.column1        # Field's value is returned as string
+    #     #=> 'a'
     #
     #     instance.column1 = 'invalid value'
     #     #=> ArgumentError
@@ -75,10 +74,6 @@ module Sequel
 
           enum_values = enum_schema[:enum_values].to_set.freeze
           self.enums[column] = enum_values
-
-          define_method "#{column}" do
-            super().to_sym
-          end
 
           define_method "#{column}=" do |value|
             val_str = value.to_s

--- a/lib/sequel/plugins/enum_guard.rb
+++ b/lib/sequel/plugins/enum_guard.rb
@@ -3,19 +3,20 @@ require 'set'
 
 module Sequel
   module Plugins
-    # Enum enhances Sequel's [pg_enum][pg_enum] types with extra runtime checking and symbol conversion.
+    # EnumGuard adds runtime checking for Sequel's [pg_enum][pg_enum] types.
     #
-    # When enabled on model's field, the plugin:
-    # - loads possible enum values from model's schema,
-    # - prevents setting incorrect value on field,
-    # - exposes known enum fields and values in `.enums` class method.
+    # When enabled, the plugin automatically searches model's schema for enum fields
+    # and adds custom setter to prevent invalid value to be set on enum field.
+    # The plugin also adds `enums` class method to the model exposing Hash of known enum fields with
+    # their value.
     #
-    # The plugin is loosely inspired by [sequel_enum][sequel_enum] plugin.
+    # The plugin was loosely inspired by [sequel_enum][sequel_enum] plugin.
     #
     # ### Example:
     #
+    #     Sequel::Model.plugin :enum_guard # The plugin is intended to be enabled globally
+    #
     #     class MyModel < Sequel::Model
-    #       plugin :enum, :column1, :column2  # Columns have to be enums, otherwise the initialization will fail
     #     end
     #
     #     MyModel.enums
@@ -33,7 +34,7 @@ module Sequel
     #
     # [pg_enum]: http://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/pg_enum_rb.html
     # [sequel_enum]: https://github.com/planas/sequel_enum
-    module Enum
+    module EnumGuard
       # @private
       def self.apply(model)
         model.instance_eval do
@@ -41,9 +42,6 @@ module Sequel
         end
       end
 
-      # Enables enum plugin for given columns.
-      # @param [Array<Symbol>]
-      # @raise [ArgumentError] if given column(s) do not exist or aren't enums
       # @return [void]
       def self.configure(model)
         model.instance_eval do

--- a/lib/sequel/plugins/enum_guard.rb
+++ b/lib/sequel/plugins/enum_guard.rb
@@ -19,7 +19,7 @@ module Sequel
     #     class MyModel < Sequel::Model
     #     end
     #
-    #     MyModel.enums
+    #     MyModel.enum_fields
     #     #=> {column1: ['a', 'b'], column2: ['c', 'd']}
     #
     #     instance = MyModel.new
@@ -52,10 +52,10 @@ module Sequel
           end
           return if columns.empty?
 
-          @enums = columns.map{ |k, v| create_enum_setter(k, v) }.to_h
-          @enums.freeze
+          @enum_fields = columns.map{ |k, v| create_enum_setter(k, v) }.to_h
+          @enum_fields.freeze
           class << self
-            attr_reader :enums
+            attr_reader :enum_fields
           end
         end
 

--- a/spec/lib/sequel/plugins/enum_guard_spec.rb
+++ b/spec/lib/sequel/plugins/enum_guard_spec.rb
@@ -40,22 +40,19 @@ describe Sequel::Plugins::EnumGuard do
     }
   end
 
+  before do
+    Sequel::Model.plugin :enum_guard
+  end
+
   context 'within global Sequel::Model' do
     subject(:model) do
-      Sequel::Model.plugin :enum_guard
       Sequel::Model
     end
 
-    it 'exposes no enum' do
-      expect(model.enums).to eq({})
-    end
+    it { should_not respond_to(:enums) }
   end
 
   context 'within model with enums' do
-    before do
-      Sequel::Model.plugin :enum_guard
-    end
-
     subject(:model) do
       class EnumTestModel < Sequel::Model
       end
@@ -63,9 +60,13 @@ describe Sequel::Plugins::EnumGuard do
     end
 
     describe '.enums' do
+      subject(:enums) { model.enums }
+
       it 'contains allowed values for enum' do
-        expect(model.enums).to eq(enums_schema)
+        expect(enums).to eq(enums_schema)
       end
+
+      it { should be_frozen }
     end
 
     describe 'instance methods' do
@@ -97,7 +98,6 @@ describe Sequel::Plugins::EnumGuard do
 
   context 'in subclass' do
     let!(:model) do
-      Sequel::Model.plugin :enum_guard
       class EnumTestModel < Sequel::Model
         plugin :single_table_inheritance, :kind
       end

--- a/spec/lib/sequel/plugins/enum_guard_spec.rb
+++ b/spec/lib/sequel/plugins/enum_guard_spec.rb
@@ -59,8 +59,8 @@ describe Sequel::Plugins::EnumGuard do
       EnumTestModel
     end
 
-    describe '.enums' do
-      subject(:enums) { model.enums }
+    describe '.enum_fields' do
+      subject(:enums) { model.enum_fields }
 
       it 'contains allowed values for enum' do
         expect(enums).to eq(enums_schema)
@@ -112,13 +112,13 @@ describe Sequel::Plugins::EnumGuard do
 
     let!(:instance) { submodel.create(enum_col: 'b') }
 
-    describe '.enums' do
+    describe '.enum_fields' do
       it 'contains allowed values for enum' do
-        expect(model.enums).to eq(enums_schema)
-        expect(submodel.enums).to eq(enums_schema)
+        expect(model.enum_fields).to eq(enums_schema)
+        expect(submodel.enum_fields).to eq(enums_schema)
       end
       it 'is a different object' do
-        expect(model.enums).to_not equal(submodel.enums)
+        expect(model.enum_fields).to_not equal(submodel.enum_fields)
       end
     end
 

--- a/spec/lib/sequel/plugins/enum_guard_spec.rb
+++ b/spec/lib/sequel/plugins/enum_guard_spec.rb
@@ -12,8 +12,8 @@ describe Sequel::Plugins::EnumGuard do
       create_table(:enum_test_models) do
         String :str_col
         String :kind
-        test_enum :enum_col
-        test_enum2 :enum_col2
+        test_enum :enum_col, null: false
+        test_enum2 :enum_col2, null: true
       end
     end
 
@@ -36,7 +36,7 @@ describe Sequel::Plugins::EnumGuard do
   let(:enums_schema) do
     {
       enum_col: Set.new(%w'a b c'),
-      enum_col2: Set.new(%w'd e f'),
+      enum_col2: Set.new(['d', 'e', 'f', nil]),
     }
   end
 
@@ -77,7 +77,11 @@ describe Sequel::Plugins::EnumGuard do
       describe 'enum setter' do
         context 'with invalid enum value' do
           it 'raises an ArgumentError' do
-            expect { instance.enum_col = 'invalid' }.to raise_error(ArgumentError)
+            expect { instance.enum_col = 'invalid val' }.to raise_error(ArgumentError)
+          end
+
+          it "doesn't accept nil value for NOT NULL field" do
+            expect { instance.enum_col = nil }.to raise_error(ArgumentError)
           end
         end
 
@@ -90,6 +94,11 @@ describe Sequel::Plugins::EnumGuard do
           it 'accepts symbol' do
             instance.enum_col = :c
             expect(instance.enum_col).to eq 'c'
+          end
+
+          it 'accepts nil for NULL columns' do
+            instance.enum_col2 = nil
+            expect(instance.enum_col2).to be_nil
           end
         end
       end

--- a/spec/lib/sequel/plugins/enum_guard_spec.rb
+++ b/spec/lib/sequel/plugins/enum_guard_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
-require 'sequel/plugins/enum'
+require 'sequel/plugins/enum_guard'
 
 Sequel.extension :migration
 
-describe Sequel::Plugins::Enum do
+describe Sequel::Plugins::EnumGuard do
   Migration = Sequel.migration do
     up do
       extension :pg_enum
@@ -46,15 +46,15 @@ describe Sequel::Plugins::Enum do
     }
   end
 
-  describe '.plugin :enum' do
+  describe '.plugin :enum_guard' do
     it 'enables enum columns' do
-      expect { model.plugin :enum }.to_not raise_error
+      expect { model.plugin :enum_guard }.to_not raise_error
     end
   end
 
   describe '.enums' do
     before do
-      model.plugin :enum
+      model.plugin :enum_guard
     end
     it 'contains allowed values for enum' do
       expect(model.enums).to eq(enums_schema)
@@ -63,7 +63,7 @@ describe Sequel::Plugins::Enum do
 
   describe 'instance methods' do
     subject(:instance) do
-      model.plugin :enum
+      model.plugin :enum_guard
       model.new
     end
 
@@ -91,7 +91,7 @@ describe Sequel::Plugins::Enum do
   context 'in subclass' do
     let!(:model) do
       class EnumTestModel < Sequel::Model
-        plugin :enum
+        plugin :enum_guard
         plugin :single_table_inheritance, :kind
       end
       EnumTestModel
@@ -107,7 +107,7 @@ describe Sequel::Plugins::Enum do
 
     describe '.enums' do
       before do
-        model.plugin :enum
+        model.plugin :enum_guard
       end
       it 'contains allowed values for enum' do
         expect(model.enums).to eq(enums_schema)

--- a/spec/lib/sequel/plugins/enum_spec.rb
+++ b/spec/lib/sequel/plugins/enum_spec.rb
@@ -67,12 +67,6 @@ describe Sequel::Plugins::Enum do
       model.plugin :enum, :enum_col, :enum_col2
       model.new
     end
-    describe 'enum getter' do
-      it 'returns value as symbol' do
-        instance.enum_col = 'a'
-        expect(instance.enum_col).to be_a(Symbol)
-      end
-    end
 
     describe 'enum setter' do
       context 'with invalid enum value' do
@@ -84,12 +78,12 @@ describe Sequel::Plugins::Enum do
       context 'with valid enum value' do
         it 'accepts string' do
           instance.enum_col = 'b'
-          expect(instance.enum_col).to eq :b
+          expect(instance.enum_col).to eq 'b'
         end
 
         it 'accepts symbol' do
           instance.enum_col = :c
-          expect(instance.enum_col).to eq :c
+          expect(instance.enum_col).to eq 'c'
         end
       end
     end

--- a/spec/lib/sequel/plugins/enum_spec.rb
+++ b/spec/lib/sequel/plugins/enum_spec.rb
@@ -34,25 +34,24 @@ describe Sequel::Plugins::Enum do
 
   let(:model) do
     class EnumTestModel < Sequel::Model
-      plugin :enum
     end
     EnumTestModel
   end
 
-  describe '.enum' do
+  describe '.plugin :enum' do
     it 'enables enum columns' do
-      expect { model.enum :enum_col, :enum_col2 }.to_not raise_error
+      expect { model.plugin :enum, :enum_col, :enum_col2 }.to_not raise_error
     end
     context 'with non-enum column' do
       it 'raises an ArgumentError' do
-        expect { model.enum :str_col }.to raise_error(ArgumentError)
+        expect { model.plugin :enum, :str_col }.to raise_error(ArgumentError)
       end
     end
   end
 
   describe '.enums' do
     before do
-      model.enum :enum_col, :enum_col2
+      model.plugin :enum, :enum_col, :enum_col2
     end
     it 'contains allowed values for enum' do
       expected = {
@@ -65,7 +64,7 @@ describe Sequel::Plugins::Enum do
 
   describe 'instance methods' do
     subject(:instance) do
-      model.enum :enum_col, :enum_col2
+      model.plugin :enum, :enum_col, :enum_col2
       model.new
     end
     describe 'enum getter' do


### PR DESCRIPTION
- Remove enum values conversion to strings
- Rename plugin from Enum to EnumGuard
- Allow plugin to be used on `Sequel::Model` class
- Create `.enum_fields` (ex `.enums`) getter only when there are any enums
- Support NULL columns