### PR TITLE
Sort events by starts_at and id when pagination is used (fixes #188)

### DIFF
--- a/app/interactors/api/filter_events.rb
+++ b/app/interactors/api/filter_events.rb
@@ -43,6 +43,7 @@ module Interactors
               end
             }
             .then_if(@type) { |q| q.where(event_type: @type) }
+            .then { |q| q.order(:starts_at, :id) }
         end
       end
 

--- a/spec/interactors/api/filter_events_spec.rb
+++ b/spec/interactors/api/filter_events_spec.rb
@@ -28,6 +28,14 @@ RSpec.shared_examples 'filtered by params' do
   end
 end
 
+RSpec.shared_examples 'sorted' do
+  subject(:sql) { events.sql }
+
+  it 'sorts events by starts_at and id' do
+    expect(events.sql).to include ' ORDER BY starts_at, id'
+  end
+end
+
 
 describe Interactors::Api::FilterEvents do
   let(:db) { Sequel.mock(fetch: { count: 120, deleted: false }) }
@@ -55,6 +63,7 @@ describe Interactors::Api::FilterEvents do
 
   context 'for JSON API format' do
     include_examples 'filtered by params'
+    it_behaves_like 'sorted'
 
     context 'with deleted param set to true' do
       before { params[:deleted] = 'true' }
@@ -78,6 +87,7 @@ describe Interactors::Api::FilterEvents do
     let(:format) { :ical }
 
     include_examples 'filtered by params'
+    it_behaves_like 'sorted'
 
     ['true', 'all'].each do |value|
       context "with deleted param set to #{value}" do


### PR DESCRIPTION
I’ve used different approach than suggested in #188. Instead of adding generic URI parameter for sorting, I’ve enabled sorting by `(starts_at, id)` when pagination is used (i.e. parameter `offset` and/or `limit` is set). Here’s why:

1. it’s easier to implement and still solves the original problem (why would anyone need to sort events by anything else than date?),
2. pagination doesn’t make much sense when records are returned in random order; that’s not a pagination, but a random subset generator.